### PR TITLE
feat: add /version endpoint returning app_version from settings

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -8,6 +8,7 @@ class Settings(BaseSettings):
     debug: bool = True
     host: str = "0.0.0.0"
     port: int = 8000
+    app_version: str = "0.1.0"
 
     class Config:
         env_file = ".env"

--- a/app/main.py
+++ b/app/main.py
@@ -15,6 +15,7 @@ def create_app() -> FastAPI:
     # Include routers
     app.include_router(health.router)
     app.include_router(memory.router)
+    app.include_router(version.router)
 
     # Add per-request latency header so clients can see server-side processing time
     @app.middleware("http")

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,2 +1,3 @@
 from . import health  # noqa: F401 
 from . import memory  # noqa: F401 
+from . import version  # noqa: F401 

--- a/app/routers/version.py
+++ b/app/routers/version.py
@@ -1,0 +1,12 @@
+from fastapi import APIRouter
+
+from ..config import get_settings
+
+router = APIRouter(prefix="/version", tags=["Info"])
+
+
+@router.get("/", summary="Application version")
+async def get_version() -> dict[str, str]:
+    """Return the running application version from settings."""
+    settings = get_settings()
+    return {"version": settings.app_version} 


### PR DESCRIPTION
Changes:

app/config.py – added app_version setting (default "0.1.0").
app/routers/version.py – new /version endpoint that returns { "version": "0.1.0" }.
app/routers/__init__.py and app/main.py – router wired in.